### PR TITLE
Components: remove unnecesary deprecation notices

### DIFF
--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -140,29 +140,6 @@ function BasicButton({
   wide,
   ...props
 }) {
-  // backward compatibility and deprecated props
-  if (iconOnly) {
-    warnOnce(
-      'Button:iconOnly',
-      `Button: "iconOnly" is deprecated, please use "display".`
-    )
-    display = 'icon'
-  }
-  if (mode === 'outline' || mode === 'secondary') {
-    warnOnce(
-      'Button:mode',
-      `Button: the mode "${mode}" is deprecated, please use "normal".`
-    )
-    mode = 'normal'
-  }
-  if (size === 'normal' || size === 'large') {
-    warnOnce(
-      'Button:size',
-      `Button: the size "${size}" is deprecated, please use "medium".`
-    )
-    size = 'medium'
-  }
-
   // prop warnings
   if (display === 'icon' && !icon) {
     warn(`Button: the display "icon" was used without providing an icon.`)

--- a/src/components/Button/ButtonIcon.js
+++ b/src/components/Button/ButtonIcon.js
@@ -32,8 +32,6 @@ function ButtonIcon({ label, children, mode, ...props }) {
 ButtonIcon.propTypes = {
   label: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
-
-  // deprecated
   mode: PropTypes.oneOf(['button']),
 }
 

--- a/src/components/ButtonBase/ButtonBase.js
+++ b/src/components/ButtonBase/ButtonBase.js
@@ -192,10 +192,6 @@ ButtonBaseWithFocus.propTypes = {
 }
 
 const LinkBase = React.forwardRef((props, ref) => {
-  warnOnce(
-    'LinkBase',
-    'LinkBase is deprecated: please use ButtonBase with a href prop instead.'
-  )
   return <ButtonBase ref={ref} {...props} />
 })
 

--- a/src/components/DataView/Box.js
+++ b/src/components/DataView/Box.js
@@ -67,12 +67,7 @@ function Box({ heading, children, padding, ...props }) {
 Box.propTypes = {
   heading: PropTypes.node,
   children: PropTypes.node,
-  padding: PropTypes.oneOfType([
-    PropTypes.number,
-
-    // deprecated
-    PropTypes.bool,
-  ]),
+  padding: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
 }
 
 export default Box

--- a/src/components/DataView/DataView.js
+++ b/src/components/DataView/DataView.js
@@ -357,13 +357,6 @@ DataView.propTypes = {
   ]),
   onStatusEmptyClear: PropTypes.func,
   emptyState: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-
-  // deprecated
-  renderEntryChild: PropTypes.func,
-  statusEmpty: PropTypes.node,
-  statusLoading: PropTypes.node,
-  statusEmptyFilters: PropTypes.node,
-  statusEmptySearch: PropTypes.node,
 }
 
 DataView.defaultProps = {

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -42,7 +42,9 @@ function useMergeBreakpoints(breakpoints) {
 
   // Only compute once by comparing values rather than object references in dependency array
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useMemo(() => ({ ...BREAKPOINTS, ...breakpoints }), [breakpoints])
+  return useMemo(() => ({ ...BREAKPOINTS, ...breakpoints }), [
+    breakpointsAsString,
+  ])
 }
 
 const LayoutContext = React.createContext({})
@@ -53,8 +55,6 @@ function useLayout() {
   return {
     layoutName,
     layoutWidth,
-
-    // deprecated
     name: layoutName,
     width: layoutWidth,
   }

--- a/src/components/TextInput/TextInput.js
+++ b/src/components/TextInput/TextInput.js
@@ -161,10 +161,6 @@ WrapperTextInput.defaultProps = {
 
 // <input type=number> (only for compat)
 function TextInputNumber(props) {
-  warnOnce(
-    'TextInputNumber',
-    'TextInputNumber is deprecated. Please use TextInput instead.'
-  )
   return <TextInput type="number" {...props} />
 }
 

--- a/src/theme/Theme.js
+++ b/src/theme/Theme.js
@@ -68,7 +68,7 @@ function prepareTheme(theme) {
           warnOnce(
             `theme:invalid:${name}`,
             `Theme: the color “${name}” is invalid and will be ignored. ` +
-              'Please check src/theme/theme-light.js in the pocketUI' +
+              'Please check src/theme/theme-dark.js in the pocketUI' +
               'repository for a list of valid colors.'
           )
           return false

--- a/src/utils/font.js
+++ b/src/utils/font.js
@@ -1,5 +1,3 @@
-import { warnOnce } from './environment'
-
 export const DEFAULT_FONT_FAMILY = 'Inter'
 export const MONOSPACE_FONT_FAMILY = 'Source Code Pro'
 
@@ -55,16 +53,7 @@ const monospaceCss = monospace =>
     `
     : ''
 
-export function font({
-  size,
-  weight,
-  smallcaps = false,
-  monospace = false,
-  deprecationNotice = true,
-}) {
-  if (deprecationNotice) {
-    warnOnce('font()', 'font() is deprecated. Please use textStyle() instead.')
-  }
+export function font({ size, weight, smallcaps = false, monospace = false }) {
   return `
     ${fontSizeCss(size)};
     ${weightCss(weight)};


### PR DESCRIPTION
Removes some unused deprecation notices, which do not apply to PocketUI.