### PR TITLE
Package: strictly have react/react-dom as peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,6 @@
     "lint-staged": "^8.1.0",
     "listr": "^0.14.3",
     "prettier": "^2.3.2",
-    "react": "^16.3.1",
-    "react-dom": "^16.3.1",
     "rollup": "^2.23.0",
     "rollup-plugin-analyzer": "^3.3.0",
     "rollup-plugin-postcss": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,8 @@ specifiers:
   postcss: ^8.3.5
   prettier: ^2.3.2
   prop-types: ^15.6.0
-  react: ^16.3.1
   react-blockies: ^1.4.0
   react-display-name: ^0.2.3
-  react-dom: ^16.3.1
   react-onclickout: ^2.0.8
   react-spring: ^7.2.11
   recursive-copy: ^2.0.9
@@ -75,26 +73,26 @@ dependencies:
   '@fontsource/manrope': 4.5.1
   '@fontsource/source-code-pro': 4.5.0
   D: 1.0.0
-  airbnb-prop-types: 2.16.0_react@16.14.0
+  airbnb-prop-types: 2.16.0
   arg: 2.0.1
   command-exists: 1.2.9
   dayjs: 1.10.7
   js-sha3: 0.8.0
   jsbi: 3.2.5
   lodash: 4.17.21
-  markdown-to-jsx: 6.11.4_react@16.14.0
+  markdown-to-jsx: 6.11.4
   popper.js: 1.16.1
   postcss: 8.3.11
   prop-types: 15.7.2
-  react-blockies: 1.4.1_react@16.14.0
+  react-blockies: 1.4.1
   react-display-name: 0.2.5
-  react-onclickout: 2.0.8_react-dom@16.14.0+react@16.14.0
-  react-spring: 7.2.11_0106054ed56650b7cf08997e12b36ef5
+  react-onclickout: 2.0.8
+  react-spring: 7.2.11_prop-types@15.7.2
   recursive-copy: 2.0.13
   token-amount: 0.1.0
-  use-inside: 0.2.0_react@16.14.0
-  use-token: 0.2.0_react@16.14.0
-  use-viewport: 0.2.0_react@16.14.0
+  use-inside: 0.2.0
+  use-token: 0.2.0
+  use-viewport: 0.2.0
 
 devDependencies:
   '@babel/cli': 7.16.0
@@ -110,7 +108,7 @@ devDependencies:
   '@svgr/core': 4.3.3
   '@svgr/plugin-prettier': 4.3.2
   '@testing-library/jest-dom': 5.15.0
-  '@testing-library/react': 9.5.0_react-dom@16.14.0+react@16.14.0
+  '@testing-library/react': 9.5.0
   babel-eslint: 10.1.0_eslint@7.32.0
   babel-plugin-styled-components: 1.13.3_styled-components@5.3.3
   eslint: 7.32.0
@@ -133,13 +131,11 @@ devDependencies:
   lint-staged: 8.2.1
   listr: 0.14.3
   prettier: 2.4.1
-  react: 16.14.0
-  react-dom: 16.14.0_react@16.14.0
   rollup: 2.60.1
   rollup-plugin-analyzer: 3.3.0
   rollup-plugin-postcss: 4.0.2_postcss@8.3.11
   rollup-plugin-progress: 1.1.2
-  styled-components: 5.3.3_react-dom@16.14.0+react@16.14.0
+  styled-components: 5.3.3
   svgo: 1.3.2
 
 packages:
@@ -1963,7 +1959,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/9.5.0_react-dom@16.14.0+react@16.14.0:
+  /@testing-library/react/9.5.0:
     resolution: {integrity: sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -1973,8 +1969,6 @@ packages:
       '@babel/runtime': 7.16.3
       '@testing-library/dom': 6.16.0
       '@types/testing-library__react': 9.1.3
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
     dev: true
 
   /@trysound/sax/0.2.0:
@@ -2221,7 +2215,7 @@ packages:
     hasBin: true
     dev: true
 
-  /airbnb-prop-types/2.16.0_react@16.14.0:
+  /airbnb-prop-types/2.16.0:
     resolution: {integrity: sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==}
     peerDependencies:
       react: ^0.14 || ^15.0.0 || ^16.0.0-alpha
@@ -2234,7 +2228,6 @@ packages:
       object.entries: 1.1.5
       prop-types: 15.7.2
       prop-types-exact: 1.2.0
-      react: 16.14.0
       react-is: 16.13.1
     dev: false
 
@@ -2600,7 +2593,7 @@ packages:
       '@babel/helper-module-imports': 7.16.0
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
-      styled-components: 5.3.3_react-dom@16.14.0+react@16.14.0
+      styled-components: 5.3.3
     dev: true
 
   /babel-plugin-syntax-jsx/6.18.0:
@@ -5917,14 +5910,13 @@ packages:
       object-visit: 1.0.1
     dev: true
 
-  /markdown-to-jsx/6.11.4_react@16.14.0:
+  /markdown-to-jsx/6.11.4:
     resolution: {integrity: sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==}
     engines: {node: '>= 4'}
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
       prop-types: 15.7.2
-      react: 16.14.0
       unquote: 1.1.1
     dev: false
 
@@ -7127,30 +7119,17 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
-  /react-blockies/1.4.1_react@16.14.0:
+  /react-blockies/1.4.1:
     resolution: {integrity: sha512-4N015X5oPNnD3xQPsiqolOFzPZSSWyc5mJhJUZShUCHtiGUxVN+1qsWTcglkHMNySux9hUofaispqcw9QkWP5Q==}
     peerDependencies:
       react: '>=15.0.0'
     dependencies:
       prop-types: 15.7.2
-      react: 16.14.0
     dev: false
 
   /react-display-name/0.2.5:
     resolution: {integrity: sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==}
     dev: false
-
-  /react-dom/16.14.0_react@16.14.0:
-    resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
-    peerDependencies:
-      react: ^16.14.0
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.7.2
-      react: 16.14.0
-      scheduler: 0.19.1
-    dev: true
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7159,17 +7138,14 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
-  /react-onclickout/2.0.8_react-dom@16.14.0+react@16.14.0:
+  /react-onclickout/2.0.8:
     resolution: {integrity: sha1-0XixP7h6SBNWdhtFSqYN9wabLaQ=}
     peerDependencies:
       react: ^15.x || ^16.x
       react-dom: ^15.x || ^16.x
-    dependencies:
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
     dev: false
 
-  /react-spring/7.2.11_0106054ed56650b7cf08997e12b36ef5:
+  /react-spring/7.2.11_prop-types@15.7.2:
     resolution: {integrity: sha512-VHoN34MTZFkvamy7Vlmcx2HR5WVSuaQQjFNlVRNyWNi+rcjYT8OcsggzeDltFycseBh8cZveYTc/iPCEe6O0Sw==}
     peerDependencies:
       prop-types: 15.x.x
@@ -7178,18 +7154,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.16.3
       prop-types: 15.7.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
     dev: false
-
-  /react/16.14.0:
-    resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.7.2
-    dev: true
 
   /read-pkg-up/7.0.1:
     resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
@@ -7602,13 +7567,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       xmlchars: 2.2.0
-    dev: true
-
-  /scheduler/0.19.1:
-    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
     dev: true
 
   /semver-compare/1.0.0:
@@ -8077,7 +8035,7 @@ packages:
     resolution: {integrity: sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==}
     dev: true
 
-  /styled-components/5.3.3_react-dom@16.14.0+react@16.14.0:
+  /styled-components/5.3.3:
     resolution: {integrity: sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -8093,8 +8051,6 @@ packages:
       babel-plugin-styled-components: 1.13.3_styled-components@5.3.3
       css-to-react-native: 3.0.0
       hoist-non-react-statics: 3.3.2
-      react: 16.14.0
-      react-dom: 16.14.0_react@16.14.0
       shallowequal: 1.1.0
       supports-color: 5.5.0
     dev: true
@@ -8446,32 +8402,29 @@ packages:
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
 
-  /use-inside/0.2.0_react@16.14.0:
+  /use-inside/0.2.0:
     resolution: {integrity: sha512-GYJSslg+NyAeASSwWk1wyc6/Bek/ACIrmuFY/bPbgUjQAVrtVvzjSNiOxNh20e7zanJz/bPxtIQIxq7EzjSPqQ==}
     peerDependencies:
       react: ^16.12.0
     dependencies:
       prop-types: 15.7.2
-      react: 16.14.0
     dev: false
 
-  /use-token/0.2.0_react@16.14.0:
+  /use-token/0.2.0:
     resolution: {integrity: sha512-lvKboDH7okV/SAb9q4Fs+kgEOS976SvHPMzpy+KCKXXVAMzG30znfsvYKiiK2Mdg+QU4vil0+NHXZ6ozuo+ysw==}
     peerDependencies:
       react: ^16.12.0
     dependencies:
       js-sha3: 0.8.0
-      react: 16.14.0
     dev: false
 
-  /use-viewport/0.2.0_react@16.14.0:
+  /use-viewport/0.2.0:
     resolution: {integrity: sha512-D3bY0Co9ZUdXCQGMTaUQZhLgpWpXFw2xbHDXccxtHyGch5oY0OVprQldEm2U5CwUuNbKMNW9n8Kyj8AlbbY4yQ==}
     peerDependencies:
       react: ^16.12.0
     dependencies:
       lodash.throttle: 4.1.1
       prop-types: 15.7.2
-      react: 16.14.0
     dev: false
 
   /use/3.1.1:


### PR DESCRIPTION
While both `react` and `react-dom` were marked as external libraries correctly on the rollup config, _and_ were included as peerdeps on the package.json, it seems that even including them as a devDependency (which should NOT be added to the bundle) will cause problems with CRA/Webpack-based apps as rollup was still including react on the bundle, for some reason.

This removes them from devDependencies and therefore, on a new project, only one version of react should be installed.